### PR TITLE
Markdown import: support leaner lists of items, under H1 categories

### DIFF
--- a/src/lib/__tests__/mdealib-articles.test.js
+++ b/src/lib/__tests__/mdealib-articles.test.js
@@ -1,0 +1,67 @@
+import * as mdealib from '../mdealib.js';
+
+
+// article tests todo 
+// - import article items under ## history 
+// - import article items under ## history with h3 context
+// - import naked list items with h3 context
+
+test( 'imports article items with H3 context', () => {
+  const md = `# #h1tag #h1concept
+
+## history
+### 20200222 banana
+
+#### article 1
+content
+
+stuff.
+
+#### article 2 
+More stuff!
+
+- including
+- article
+- list
+
+### 20200223
+
+#### article 3
+content
+
+stuff.
+
+#### article 4
+More stuff!
+
+- including
+- article
+- list
+
+`;
+
+    const imported = mdealib.importMarkdownDiary( md );
+    expect( imported ).toHaveLength( 4 );
+
+    expect( imported[0] ).toEqual(
+    expect.objectContaining( {
+      content: `content
+
+stuff.`,
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }, {
+        depth: 2, 
+        markdown: '## history',
+      }, {
+        depth: 3, 
+        markdown: '### 20200222 banana',
+      }, {
+        depth: 4,
+        markdown: '#### article 1',
+      }],
+      type: 'headingItem',
+    } )
+  );
+} );

--- a/src/lib/__tests__/mdealib-articles.test.js
+++ b/src/lib/__tests__/mdealib-articles.test.js
@@ -1,10 +1,59 @@
 import * as mdealib from '../mdealib.js';
 
+test( 'imports article items with no H3 context', () => {
+  const md = `# #h1tag #h1concept
 
-// article tests todo 
-// - import article items under ## history 
-// - import article items under ## history with h3 context
-// - import naked list items with h3 context
+## history
+#### article 1
+content
+
+stuff.
+
+#### article 2 
+More stuff!
+
+- including
+- article
+- list
+
+### 20200223
+
+#### article 3
+content
+
+stuff.
+
+#### article 4
+More stuff!
+
+- including
+- article
+- list
+
+`;
+
+    const imported = mdealib.importMarkdownDiary( md );
+    expect( imported ).toHaveLength( 4 );
+
+    expect( imported[0] ).toEqual(
+    expect.objectContaining( {
+      content: `content
+
+stuff.`,
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }, {
+        depth: 2, 
+        markdown: '## history',
+      }, {
+        depth: 4,
+        markdown: '#### article 1',
+      }],
+      type: 'headingItem',
+    } )
+  );
+} );
 
 test( 'imports article items with H3 context', () => {
   const md = `# #h1tag #h1concept

--- a/src/lib/__tests__/mdealib-empty.test.js
+++ b/src/lib/__tests__/mdealib-empty.test.js
@@ -1,0 +1,60 @@
+import * as mdealib from '../mdealib.js';
+
+test( 'empty input produces no items', () => {
+   expect(
+      mdealib.importMarkdownDiary( '' )
+   ).toEqual( [ ] );
+
+   expect(
+      mdealib.importMarkdownDiary( '   ' )
+   ).toEqual( [ ] );
+
+   expect(
+      mdealib.importMarkdownDiary( '# #h1tag #h1concept   ' )
+   ).toEqual( [ ] );
+
+   expect(
+      mdealib.importMarkdownDiary( `# #h1tag #h1concept   
+
+
+` )
+   ).toEqual( [ ] );
+
+   expect(
+      mdealib.importMarkdownDiary( `# #h1tag #h1concept   
+
+## history
+
+` )
+   ).toEqual( [ ] );
+
+   expect(
+      mdealib.importMarkdownDiary( `# #h1tag #h1concept   
+
+## tasks
+
+` )
+   ).toEqual( [ ] );
+
+   expect(
+      mdealib.importMarkdownDiary( `# #h1tag #h1concept   
+
+## tasks
+
+## history
+
+` )
+   ).toEqual( [ ] );
+
+   expect(
+      mdealib.importMarkdownDiary( `# #h1tag #h1concept   
+
+## history
+
+### 20200401
+
+` )
+   ).toEqual( [ ] );
+} );
+
+

--- a/src/lib/__tests__/mdealib-lists.test.js
+++ b/src/lib/__tests__/mdealib-lists.test.js
@@ -363,3 +363,64 @@ a dangler on the end with
 } );
 
 
+test( 'imports list items with H2 ## tasks in the middle and H3 context', () => {
+  const md = `# #h1tag #h1concept
+            
+item 1
+      
+### 20200222 banana
+
+item 2
+
+## tasks
+
+item 3 with nested stuff
+  this is nested
+  and this too
+`;
+
+  const imported = mdealib.importMarkdownDiary( md );
+  expect( imported ).toHaveLength( 3 );
+  expect( imported[0] ).toEqual(
+    expect.objectContaining( {
+      content: 'item 1',
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }],
+      type: 'listItem',
+    } )
+  );
+  expect( imported[1] ).toEqual(
+    expect.objectContaining( {
+      content: 'item 2',
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }, {
+        depth: 3, 
+        markdown: '### 20200222 banana',
+      }],
+      type: 'listItem',
+    } )
+  );
+  expect( imported[2] ).toEqual(
+    expect.objectContaining( {
+      content: `item 3 with nested stuff
+  this is nested
+  and this too`,
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }, {
+        depth: 2, 
+        markdown: '## tasks',
+      }
+      // H3 context is reset by H2 ## tasks
+      ],
+      type: 'listItem',
+    } )
+  );
+} );
+
+

--- a/src/lib/__tests__/mdealib-lists.test.js
+++ b/src/lib/__tests__/mdealib-lists.test.js
@@ -1,0 +1,365 @@
+import * as mdealib from '../mdealib.js';
+
+test( 'imports naked list items', () => {
+  const md = `# #h1tag #h1concept
+
+item 1
+
+item 2
+
+item 3 with nested stuff
+  this is nested
+      and this too
+`;
+
+  const imported = mdealib.importMarkdownDiary( md );
+  expect( imported ).toHaveLength( 3 );
+  expect( imported[1] ).toEqual(
+    expect.objectContaining( {
+      content: 'item 2',
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }],
+      type: 'listItem',
+    } )
+    );
+  expect( imported[2] ).toEqual(
+    expect.objectContaining( {
+      content: `item 3 with nested stuff
+  this is nested
+      and this too`,
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }],
+      type: 'listItem',
+    } )
+    );
+} );
+
+test( 'imports naked bullet point items', () => {
+  const md = `# #h1tag #h1concept
+
+- item 1
+- item with nested stuff
+    this is nested
+  -and this too
+- another item
+
+`;
+
+  const imported = mdealib.importMarkdownDiary( md );
+  expect( imported ).toHaveLength( 3 );
+  expect( imported[0] ).toEqual(
+    expect.objectContaining( {
+      content: '- item 1',
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }],
+      type: 'listItem',
+    } )
+    );
+  expect( imported[1] ).toEqual(
+    expect.objectContaining( {
+      content: `- item with nested stuff
+    this is nested
+  -and this too`,
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }],
+      type: 'listItem',
+    } )
+    );
+} );
+
+
+test( 'imports naked mixed list items and bullet points', () => {
+  const md = `# #h1tag #h1concept
+
+- item 1
+
+inserted item with some cool info
+
+- item with nested stuff
+  this is nested
+  and this too
+- another item
+
+a dangler on the end with
+  - some nested
+  stuff
+
+`;
+
+  const imported = mdealib.importMarkdownDiary( md );
+  expect( imported ).toHaveLength( 5 );
+  expect( imported[0] ).toEqual(
+    expect.objectContaining( {
+      content: '- item 1',
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }],
+      type: 'listItem',
+    } )
+    );
+  expect( imported[1] ).toEqual(
+    expect.objectContaining( {
+      content: 'inserted item with some cool info',
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }],
+      type: 'listItem',
+    } )
+    );
+  expect( imported[2] ).toEqual(
+    expect.objectContaining( {
+      content: `- item with nested stuff
+  this is nested
+  and this too`,
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }],
+      type: 'listItem',
+    } )
+    );
+  expect( imported[3] ).toEqual(
+    expect.objectContaining( {
+      content: '- another item',
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }],
+      type: 'listItem',
+    } )
+    );
+  expect( imported[4] ).toEqual(
+    expect.objectContaining( {
+      content: `a dangler on the end with
+  - some nested
+  stuff`,
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }],
+      type: 'listItem',
+    } )
+    );
+} );
+
+test( 'imports list items with H2 ## tasks in the middle', () => {
+  const md = `# #h1tag #h1concept
+            
+item 1
+      
+item 2
+
+## tasks
+
+item 3 with nested stuff
+  this is nested
+  and this too
+`;
+
+  const imported = mdealib.importMarkdownDiary( md );
+  expect( imported ).toHaveLength( 3 );
+  expect( imported[1] ).toEqual(
+    expect.objectContaining( {
+      content: 'item 2',
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }],
+      type: 'listItem',
+    } )
+    );
+  expect( imported[2] ).toEqual(
+    expect.objectContaining( {
+      content: `item 3 with nested stuff
+  this is nested
+  and this too`,
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }, {
+        depth: 2, 
+        markdown: '## tasks',
+      }],
+      type: 'listItem',
+    } )
+    );
+} );
+
+test( 'imports bullet point items under H2 ## tasks', () => {
+  const md = `# #h1tag #h1concept
+
+## tasks
+
+- item 1
+- item with nested stuff
+  this is nested
+    and this too
+- another item
+
+`;
+
+  const imported = mdealib.importMarkdownDiary( md );
+  expect( imported ).toHaveLength( 3 );
+  expect( imported[0] ).toEqual(
+    expect.objectContaining( {
+      content: '- item 1',
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }, {
+        depth: 2, 
+        markdown: '## tasks',
+      }],
+      type: 'listItem',
+    } )
+    );
+  expect( imported[1] ).toEqual(
+    expect.objectContaining( {
+      content: `- item with nested stuff
+  this is nested
+    and this too`,
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }, {
+        depth: 2, 
+        markdown: '## tasks',
+      }],
+      type: 'listItem',
+    } )
+    );
+  expect( imported[2] ).toEqual(
+    expect.objectContaining( {
+      content: '- another item',
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }, {
+        depth: 2, 
+        markdown: '## tasks',
+      }],
+      type: 'listItem',
+    } )
+    );
+} );
+
+
+test( 'imports mixed list items and bullet point under H2 ## tasks', () => {
+  const md = `# #h1tag #h1concept
+
+## tasks
+
+bananas
+
+inserted item with some cool info
+
+- item with nested stuff
+  this is nested
+  and this too
+- another item
+
+a dangler on the end with
+  - some nested
+  stuff
+
+- last item
+
+`;
+
+  const imported = mdealib.importMarkdownDiary( md );
+  expect( imported ).toHaveLength( 6 );
+  expect( imported[0] ).toEqual(
+    expect.objectContaining( {
+      content: 'bananas',
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }, {
+        depth: 2, 
+        markdown: '## tasks',
+      }],
+      type: 'listItem',
+    } )
+    );
+  expect( imported[1] ).toEqual(
+    expect.objectContaining( {
+      content: 'inserted item with some cool info',
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }, {
+        depth: 2, 
+        markdown: '## tasks',
+      }],
+      type: 'listItem',
+    } )
+    );
+  expect( imported[2] ).toEqual(
+    expect.objectContaining( {
+      content: `- item with nested stuff
+  this is nested
+  and this too`,
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }, {
+        depth: 2, 
+        markdown: '## tasks',
+      }],
+      type: 'listItem',
+    } )
+    );
+  expect( imported[3] ).toEqual(
+    expect.objectContaining( {
+      content: '- another item',
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }, {
+        depth: 2, 
+        markdown: '## tasks',
+      }],
+      type: 'listItem',
+    } )
+    );
+  expect( imported[4] ).toEqual(
+    expect.objectContaining( {
+      content: `a dangler on the end with
+  - some nested
+  stuff`,
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }, {
+        depth: 2, 
+        markdown: '## tasks',
+      }],
+      type: 'listItem',
+    } )
+    );
+  expect( imported[5] ).toEqual(
+    expect.objectContaining( {
+      content: '- last item',
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }, {
+        depth: 2, 
+        markdown: '## tasks',
+      }],
+      type: 'listItem',
+    } )
+    );
+} );
+
+

--- a/src/lib/__tests__/mdealib-mixed.test.js
+++ b/src/lib/__tests__/mdealib-mixed.test.js
@@ -1,0 +1,296 @@
+import * as mdealib from '../mdealib.js';
+
+test( 'imports mixed lists and articles', () => {
+  const md = `# #h1tag #h1concept
+
+## history
+#### article 1
+content
+
+stuff.
+
+#### article 2 
+More stuff!
+
+- including
+- article
+- list
+
+### 20200223
+
+#### article 3
+content
+
+stuff.
+
+## tasks
+
+- task 1
+- task 2
+  nested
+
+### 20200223
+
+- task other
+
+## history
+
+#### article 4
+More stuff!
+
+- including
+- article
+- list
+
+`;
+
+  const imported = mdealib.importMarkdownDiary( md );
+  expect( imported ).toHaveLength( 7 );
+
+  expect( imported[0] ).toEqual(
+    expect.objectContaining( {
+      content: `content
+
+stuff.`,
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }, {
+        depth: 2, 
+        markdown: '## history',
+      }, {
+        depth: 4,
+        markdown: '#### article 1',
+      }],
+      type: 'headingItem',
+    } )
+  );
+  expect( imported[1] ).toEqual(
+    expect.objectContaining( {
+      content: `More stuff!
+
+- including
+- article
+- list`,
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }, {
+        depth: 2, 
+        markdown: '## history',
+      }, {
+        // note this H3 is picked up within the article
+        depth: 3, 
+        markdown: '### 20200223',
+      }, 
+      // and it obliterates the actual article title
+      // this is not ideal .. 
+      // {
+      //   depth: 4,
+      //   markdown: '#### article 2',
+      // }
+      ],
+      type: 'headingItem',
+    } )
+  );
+  expect( imported[2] ).toEqual(
+    expect.objectContaining( {
+      content: `content
+
+stuff.`,
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }, {
+        depth: 2, 
+        markdown: '## history',
+      }, {
+        depth: 3, 
+        markdown: '### 20200223',
+      }, {
+        depth: 4,
+        markdown: '#### article 3',
+      }],
+      type: 'headingItem',
+    } )
+  );
+  expect( imported[3] ).toEqual(
+    expect.objectContaining( {
+      content: `- task 1`,
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }, {
+        depth: 2, 
+        markdown: '## tasks',
+      }],
+      type: 'listItem',
+    } )
+  );
+  expect( imported[4] ).toEqual(
+    expect.objectContaining( {
+      content: `- task 2
+  nested`,
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }, {
+        depth: 2, 
+        markdown: '## tasks',
+      }],
+      type: 'listItem',
+    } )
+  );
+  expect( imported[5] ).toEqual(
+    expect.objectContaining( {
+      content: `- task other`,
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }, {
+        depth: 2, 
+        markdown: '## tasks',
+      }, {
+        depth: 3, 
+        markdown: '### 20200223',
+      }],
+      type: 'listItem',
+    } )
+  );
+} );
+
+
+test( 'imports mixed lists and articles, tasks all implicit', () => {
+  const md = `# #h1tag #h1concept
+
+- task 1
+- task 2
+  nested
+
+### 20200223
+
+- task other
+
+### 20200322 banana apple orange
+
+Sentence task.
+
+Paragraph #task. With #multiple sentences.
+
+A short sentence.
+   with some nested 
+  - things
+
+## history
+
+### 20200406
+
+#### article
+More stuff!
+
+In an article.
+
+`;
+
+  const imported = mdealib.importMarkdownDiary( md );
+  expect( imported ).toHaveLength( 7 );
+
+  expect( imported[0] ).toEqual(
+    expect.objectContaining( {
+      content: '- task 1',
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }],
+      type: 'listItem',
+    } )
+  );
+  expect( imported[1] ).toEqual(
+    expect.objectContaining( {
+      content: `- task 2
+  nested`,
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }],
+      type: 'listItem',
+    } )
+  );
+  expect( imported[2] ).toEqual(
+    expect.objectContaining( {
+      content: '- task other',
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }, {
+        depth: 3, 
+        markdown: '### 20200223',
+      }],
+      type: 'listItem',
+    } )
+  );
+  expect( imported[3] ).toEqual(
+    expect.objectContaining( {
+      content: 'Sentence task.',
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }, {
+        depth: 3, 
+        markdown: '### 20200322 banana apple orange',
+      }],
+      type: 'listItem',
+    } )
+  );
+  expect( imported[4] ).toEqual(
+    expect.objectContaining( {
+      content: 'Paragraph #task. With #multiple sentences.',
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }, {
+        depth: 3, 
+        markdown: '### 20200322 banana apple orange',
+      }],
+      type: 'listItem',
+    } )
+  );
+  expect( imported[5] ).toEqual(
+    expect.objectContaining( {
+      content: `A short sentence.
+   with some nested 
+  - things`,
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }, {
+        depth: 3, 
+        markdown: '### 20200322 banana apple orange',
+      }],
+      type: 'listItem',
+    } )
+  );
+  expect( imported[6] ).toEqual(
+    expect.objectContaining( {
+      content: `More stuff!
+
+In an article.`,
+      context: [{
+        depth: 1, 
+        markdown: '# #h1tag #h1concept',
+      }, {
+        depth: 2, 
+        markdown: '## history',
+      }, {
+        depth: 3, 
+        markdown: '### 20200406',
+      }, {
+        depth: 4, 
+        markdown: '#### article',
+      }],
+      type: 'headingItem',
+    } )
+  );
+
+
+} );

--- a/src/lib/__tests__/mdealib-multi-context.test.js
+++ b/src/lib/__tests__/mdealib-multi-context.test.js
@@ -1,12 +1,5 @@
 import * as mdealib from '../mdealib.js';
 
-// multiple h1 context tests todo
-// tasks and history h2 present, under different h1 sections
-// history then tasks, under different h1 sections
-// as above, no h2s, all lists
-// as above, occasional history section, correctly default to list
-
-
 test( 'imports list items grouped by H1 context', () => {
   const md = `# #fun #drama #conflict
 
@@ -219,6 +212,133 @@ do a job
       }, {
         depth: 3, 
         markdown: '### 20201213',
+      }],
+      type: 'listItem',
+    } )
+  );
+
+} );
+
+test( 'imports list items and article items grouped by H1 context with H3 context', () => {
+  const md = `# #fun #drama #conflict
+
+- watch 124
+
+## history
+### 20201212
+#### played a game of squash.
+With Johnson. And I won. Tough competitor.
+
+Afterward we celebrated by eating chips and drinking Fresh Up®.
+
+# #work #business #commerce
+
+### 20201212
+
+task 1
+
+do a job
+  and then some
+
+## history
+
+
+## tasks
+
+### 20201213
+- get a haircut
+
+## tasks
+- shake a tower
+`;
+
+  const imported = mdealib.importMarkdownDiary( md );
+  expect( imported ).toHaveLength( 6 );
+
+  expect( imported[0] ).toEqual(
+    expect.objectContaining( {
+      content: '- watch 124',
+      context: [{
+        depth: 1, 
+        markdown: '# #fun #drama #conflict',
+      }],
+      type: 'listItem',
+    } )
+  );
+  expect( imported[1] ).toEqual(
+    expect.objectContaining( {
+      content: `With Johnson. And I won. Tough competitor.
+
+Afterward we celebrated by eating chips and drinking Fresh Up®.`,
+      context: [{
+        depth: 1, 
+        markdown: '# #fun #drama #conflict',
+      }, {
+        depth: 2, 
+        markdown: '## history',
+      }, {
+        depth: 3, 
+        markdown: '### 20201212',
+      }, {
+        depth: 4, 
+        markdown: '#### played a game of squash.',
+      }],
+      type: 'headingItem',
+    } )
+  );
+
+  expect( imported[2] ).toEqual(
+    expect.objectContaining( {
+      content: 'task 1',
+      context: [{
+        depth: 1, 
+        markdown: '# #work #business #commerce',
+      }, {
+        depth: 3, 
+        markdown: '### 20201212',
+      }],
+      type: 'listItem',
+    } )
+  );
+  expect( imported[3] ).toEqual(
+    expect.objectContaining( {
+      content: `do a job
+  and then some`,
+      context: [{
+        depth: 1, 
+        markdown: '# #work #business #commerce',
+      }, {
+        depth: 3, 
+        markdown: '### 20201212',
+      }],
+      type: 'listItem',
+    } )
+  );
+  expect( imported[4] ).toEqual(
+    expect.objectContaining( {
+      content: '- get a haircut',
+      context: [{
+        depth: 1, 
+        markdown: '# #work #business #commerce',
+      }, {
+        depth: 2, 
+        markdown: '## tasks',
+      }, {
+        depth: 3, 
+        markdown: '### 20201213',
+      }],
+      type: 'listItem',
+    } )
+  );
+  expect( imported[5] ).toEqual(
+    expect.objectContaining( {
+      content: '- shake a tower',
+      context: [{
+        depth: 1, 
+        markdown: '# #work #business #commerce',
+      }, {
+        depth: 2, 
+        markdown: '## tasks',
       }],
       type: 'listItem',
     } )

--- a/src/lib/__tests__/mdealib-multi-context.test.js
+++ b/src/lib/__tests__/mdealib-multi-context.test.js
@@ -104,3 +104,125 @@ do a job
 
 } );
 
+test( 'imports list items grouped by H1 context with H3 context', () => {
+  const md = `# #fun #drama #conflict
+
+- watch 124
+
+### 20201212
+
+- watch 409
+
+eat chips daringly
+
+# #work #business #commerce
+
+### 20201212
+
+task 1
+
+do a job
+  and then some
+
+### 20201213
+
+- get a haircut
+- shake a tower
+`;
+
+  const imported = mdealib.importMarkdownDiary( md );
+  expect( imported ).toHaveLength( 7 );
+
+  expect( imported[0] ).toEqual(
+    expect.objectContaining( {
+      content: '- watch 124',
+      context: [{
+        depth: 1, 
+        markdown: '# #fun #drama #conflict',
+      }],
+      type: 'listItem',
+    } )
+  );
+  expect( imported[1] ).toEqual(
+    expect.objectContaining( {
+      content: '- watch 409',
+      context: [{
+        depth: 1, 
+        markdown: '# #fun #drama #conflict',
+      }, {
+        depth: 3, 
+        markdown: '### 20201212',
+      }],
+      type: 'listItem',
+    } )
+  );
+  expect( imported[2] ).toEqual(
+    expect.objectContaining( {
+      content: 'eat chips daringly',
+      context: [{
+        depth: 1, 
+        markdown: '# #fun #drama #conflict',
+      }, {
+        depth: 3, 
+        markdown: '### 20201212',
+      }],
+      type: 'listItem',
+    } )
+  );
+
+  expect( imported[3] ).toEqual(
+    expect.objectContaining( {
+      content: 'task 1',
+      context: [{
+        depth: 1, 
+        markdown: '# #work #business #commerce',
+      }, {
+        depth: 3, 
+        markdown: '### 20201212',
+      }],
+      type: 'listItem',
+    } )
+  );
+  expect( imported[4] ).toEqual(
+    expect.objectContaining( {
+      content: `do a job
+  and then some`,
+      context: [{
+        depth: 1, 
+        markdown: '# #work #business #commerce',
+      }, {
+        depth: 3, 
+        markdown: '### 20201212',
+      }],
+      type: 'listItem',
+    } )
+  );
+  expect( imported[5] ).toEqual(
+    expect.objectContaining( {
+      content: '- get a haircut',
+      context: [{
+        depth: 1, 
+        markdown: '# #work #business #commerce',
+      }, {
+        depth: 3, 
+        markdown: '### 20201213',
+      }],
+      type: 'listItem',
+    } )
+  );
+  expect( imported[6] ).toEqual(
+    expect.objectContaining( {
+      content: '- shake a tower',
+      context: [{
+        depth: 1, 
+        markdown: '# #work #business #commerce',
+      }, {
+        depth: 3, 
+        markdown: '### 20201213',
+      }],
+      type: 'listItem',
+    } )
+  );
+
+} );
+

--- a/src/lib/__tests__/mdealib-multi-context.test.js
+++ b/src/lib/__tests__/mdealib-multi-context.test.js
@@ -1,0 +1,106 @@
+import * as mdealib from '../mdealib.js';
+
+// multiple h1 context tests todo
+// tasks and history h2 present, under different h1 sections
+// history then tasks, under different h1 sections
+// as above, no h2s, all lists
+// as above, occasional history section, correctly default to list
+
+
+test( 'imports list items grouped by H1 context', () => {
+  const md = `# #fun #drama #conflict
+
+- watch 124
+- watch 409
+
+eat chips daringly
+
+# #work #business #commerce
+
+task 1
+
+do a job
+  and then some
+
+- get a haircut
+- shake a tower
+`;
+
+  const imported = mdealib.importMarkdownDiary( md );
+  expect( imported ).toHaveLength( 7 );
+
+  expect( imported[0] ).toEqual(
+    expect.objectContaining( {
+      content: '- watch 124',
+      context: [{
+        depth: 1, 
+        markdown: '# #fun #drama #conflict',
+      }],
+      type: 'listItem',
+    } )
+  );
+  expect( imported[1] ).toEqual(
+    expect.objectContaining( {
+      content: '- watch 409',
+      context: [{
+        depth: 1, 
+        markdown: '# #fun #drama #conflict',
+      }],
+      type: 'listItem',
+    } )
+  );
+  expect( imported[2] ).toEqual(
+    expect.objectContaining( {
+      content: 'eat chips daringly',
+      context: [{
+        depth: 1, 
+        markdown: '# #fun #drama #conflict',
+      }],
+      type: 'listItem',
+    } )
+  );
+
+  expect( imported[3] ).toEqual(
+    expect.objectContaining( {
+      content: 'task 1',
+      context: [{
+        depth: 1, 
+        markdown: '# #work #business #commerce',
+      }],
+      type: 'listItem',
+    } )
+  );
+  expect( imported[4] ).toEqual(
+    expect.objectContaining( {
+      content: `do a job
+  and then some`,
+      context: [{
+        depth: 1, 
+        markdown: '# #work #business #commerce',
+      }],
+      type: 'listItem',
+    } )
+  );
+  expect( imported[5] ).toEqual(
+    expect.objectContaining( {
+      content: '- get a haircut',
+      context: [{
+        depth: 1, 
+        markdown: '# #work #business #commerce',
+      }],
+      type: 'listItem',
+    } )
+  );
+  expect( imported[6] ).toEqual(
+    expect.objectContaining( {
+      content: '- shake a tower',
+      context: [{
+        depth: 1, 
+        markdown: '# #work #business #commerce',
+      }],
+      type: 'listItem',
+    } )
+  );
+
+} );
+

--- a/src/lib/mdealib.js
+++ b/src/lib/mdealib.js
@@ -76,7 +76,7 @@ export function importMarkdownDiary(mdsrc, splitHeadingLevel, filename) {
 
       // what are we looking at? heading or other
       if (!ignoringLinesForFencedBlock && 
-         tokens.length && tokens[0].type == 'heading' && 
+         tokens.length && tokens[0].type === 'heading' && 
          tokens[0].depth <= splitHeadingLevel) {
          // this is a heading we might split on..
          var headingLevel = tokens[0].depth;
@@ -84,18 +84,18 @@ export function importMarkdownDiary(mdsrc, splitHeadingLevel, filename) {
 
          // if we are h2, check whether we change mode
          var prevMode = mode;
-         if (headingLevel == 2) {
-            if (headingText == 'tasks') {
+         if (headingLevel === 2) {
+            if (headingText === 'tasks') {
                mode = 'listItem';
             }
-            else if (headingText == 'history') {
+            else if (headingText === 'history') {
                mode = 'headingItem';
             }
             else { mode = 'idle'; }
          }
 
          // are we on a new item?
-         var modeChanged = prevMode != mode;
+         var modeChanged = prevMode !== mode;
          var newDiaryItem = (headingLevel <= splitHeadingLevel);
          if (newDiaryItem || modeChanged) {
             makeNextItem();
@@ -115,7 +115,7 @@ export function importMarkdownDiary(mdsrc, splitHeadingLevel, filename) {
       else {
          // if we've just finished a listitem, bump and move on
          let isSubitem = startsWithWhitespace.test(line);
-         if (mode == 'listItem' && !isSubitem) {
+         if (mode === 'listItem' && !isSubitem) {
             makeNextItem();
          }
 
@@ -136,7 +136,7 @@ export function importMarkdownDiary(mdsrc, splitHeadingLevel, filename) {
    });
 
    tidyItems = _.filter(tidyItems, function(tidy) {
-      var typeOk = tidy.type == 'listItem' || tidy.type == 'headingItem';
+      var typeOk = tidy.type === 'listItem' || tidy.type === 'headingItem';
       var contentOk = tidy.content.length;
       return (contentOk && typeOk);
    });


### PR DESCRIPTION
Example file:

```markdown
# idea task 

Something to do.

Another thing.

# musiclistening music 

__Fatima Yamaha__ will get indexed because bold

Rod Stewart - just a reminder to listen
```

This works alongside to the H3 context tags and H4-delimited `headingItem` (`## history`) and `listItem` (`## tasks`) support.

The import parser now defaults to `listItem` mode, so `## tasks` is optional. 