### PR TITLE
add "wurd" random name/word generator

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -32,12 +32,21 @@ import Pagination from './components/Pagination';
 import TagCloud from './components/TagCloud';
 import Items from './components/Items';
 import Item from './components/Item';
+import RandomWurd from './components/RandomWurd';
 import Navigation from './components/Navigation';
 
 import './style/App.scss';
 
 function useQuery() {
   return new URLSearchParams( useLocation().search );
+}
+
+function RandomWurdView() {
+  return (
+    <div className='app'>
+      <RandomWurd />
+    </div>
+   );
 }
 
 function ArticleView() {
@@ -124,6 +133,9 @@ function App() {
           <Navigation />
 
           <Switch>
+            <Route path="/wurd" children={ 
+                <RandomWurdView />
+            } />
             <Route path="/item/:id" children={ 
                 <HydratedArticleView />
             } />

--- a/src/components/RandomWurd.js
+++ b/src/components/RandomWurd.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import randomPseudoword from '../lib/random-pseudoword';
+
+function RandomWurd() {
+  const title = randomPseudoword( { capitalize: true } );
+  const word = randomPseudoword( { capitalize: false } );
+
+  return (
+    <div className='article wurd' >
+      <h2 className='title'>{ title }</h2>
+      <div className='content'>{ word }</div>
+    </div> 
+  );
+}
+
+export default RandomWurd;

--- a/src/lib/random-pseudoword.js
+++ b/src/lib/random-pseudoword.js
@@ -1,0 +1,70 @@
+import _ from 'lodash';
+
+const defaults = function(options, defaultValues) {
+  options = options || {};
+  return _.defaults(options, defaultValues);
+};
+
+const randomInteger = function(options) {
+  options = defaults(options, {
+    max: 10,
+    min: 0
+  });
+  return Math.floor((Math.random() * (options.max - options.min)) + options.min);
+};
+
+const arrayModAt = function(array, index) {
+  return array[index % array.length];
+};
+
+export const randomPseudoword = (options) => {
+  options = defaults(options, {
+    maxSyllables: 5,
+    minSyllables: 3,
+    capitalize: true
+  });
+
+  let
+    consonants = "bcdfghjklmnpqrstvwxyz",
+    vowels = [
+      'a', 'e', 'i', 'o', 'u', 'y'
+    ],
+    longvowels = [
+      'ee', 'oo'
+    ],
+    dipthongs = [
+      'ae', 'ai', 'ao', 'au',
+      'ea', 'ei', 'eo', 'eu',
+      'ia', 'ie', 'io', 'iu',
+      'oa', 'oe', 'oi', 'ou'
+    ];
+
+  // shuffle our materials; shuffle two copies so can have repeats
+  consonants = _.shuffle(consonants + consonants);
+  vowels = _.shuffle(vowels.concat(vowels));
+  longvowels = _.shuffle(longvowels.concat(longvowels));
+
+  const syllables = randomInteger({ min: options.minSyllables, max: options.maxSyllables });
+  let word = '';
+  for (var i=0; i<syllables; i++) {
+     var mode = randomInteger({max: 20});
+     if (mode >= 18) {
+        word += arrayModAt(consonants, i) + arrayModAt(dipthongs, i);
+     }
+     else if (mode >= 16) {
+        word += arrayModAt(consonants, i) + arrayModAt(longvowels, i);
+     }
+     else if (mode === 6) {
+        word += arrayModAt(consonants, i);
+     }
+     else {
+        word += arrayModAt(consonants, i) + arrayModAt(vowels, i);
+     }
+  }
+  
+  if (options.capitalize) {
+     word = word.charAt(0).toUpperCase() + word.slice(1);
+  }
+  
+  return word;
+}

--- a/src/lib/random-pseudoword.js
+++ b/src/lib/random-pseudoword.js
@@ -17,7 +17,7 @@ const arrayModAt = function(array, index) {
   return array[index % array.length];
 };
 
-export const randomPseudoword = (options) => {
+const randomPseudoword = (options) => {
   options = defaults(options, {
     maxSyllables: 5,
     minSyllables: 3,
@@ -68,3 +68,5 @@ export const randomPseudoword = (options) => {
   
   return word;
 }
+
+export default randomPseudoword;


### PR DESCRIPTION
Adds new page route for generating random words for project codenames (e.g. instead of "untitled").

- New route `/wurd`
- Generates two words, one captialised title and one all lowercase

Action shot:

<img width="883" alt="Screen Shot 2020-04-18 at 1 29 59 PM" src="https://user-images.githubusercontent.com/4167300/79624849-b589ff80-8178-11ea-93c8-6e85db0d4778.png">
