### PR TITLE
limit tag browser and move to top

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -90,9 +90,9 @@ function HydratedArticleView() {
 function ListView() {
   return (
     <div className='app'>
+      <TagCloud />
       <Items />
       <Pagination />
-      <TagCloud />
     </div>
    );
 }

--- a/src/components/TagCloud.js
+++ b/src/components/TagCloud.js
@@ -11,7 +11,7 @@ import { listUrl } from '../lib/route-url';
 import Tag from './Tag';
 
 function tagFontSize( tagHitCount, maxHitCount ) {
-  const minSize = 8, sizeRange = 30;
+  const minSize = 6, sizeRange = 36;
   var size = 0;
   size = tagHitCount / maxHitCount;
   size = size * sizeRange;

--- a/src/lib/mongo-query.js
+++ b/src/lib/mongo-query.js
@@ -5,11 +5,12 @@ export const DEFAULT_PAGINATION = {
    skipToItem: 0
 };
 
-export function formatMongoSearchQuery( tagsArray, textSearch, startDate, endDate, max, skip ) {
-   var query = {}, clauses = [];
+export function formatMongoSearchQuery( args ) {
+   const { tags: tagsArray, excludeTags, search: textSearch, startDate, endDate } = args;
+   let query = {}, clauses = [];
 
-   var startDateNum = Date.parse( startDate );
-   var endDateNum = Date.parse( endDate );
+   let startDateNum = Date.parse( startDate );
+   let endDateNum = Date.parse( endDate );
    if ( startDate && _.isFinite( startDateNum ) ) {
       clauses.push( {
          originated: {
@@ -29,6 +30,14 @@ export function formatMongoSearchQuery( tagsArray, textSearch, startDate, endDat
       clauses.push({
          lowerCaseTags: {
             $all: _.map( tagsArray, tag => tag.toLowerCase() )
+         }
+      });
+   }
+   
+   if ( excludeTags && excludeTags.length ) {
+      clauses.push({
+         lowerCaseTags: {
+            $nin: _.map( excludeTags, tag => tag.toLowerCase() )
          }
       });
    }

--- a/src/store/list/actions.js
+++ b/src/store/list/actions.js
@@ -25,19 +25,19 @@ export const setFilterTags = createAction( 'list/setFilterTags' );
 export const setFilterSearch = createAction( 'list/setFilterSearch' );
 
 const fetchTags = async ( { tags = [], search = '' } ) => {
-  const mongoQuery = JSON.stringify( formatMongoSearchQuery( tags, search ) );
+  const mongoQuery = JSON.stringify( formatMongoSearchQuery( { tags, search } ) );
   const response = await fetch( `${ apiBase }tags?query=${ mongoQuery }` );
   return response.json();
 }
 
 const fetchItems = async ( { limit = 1, skip = 0, tags = [], search = '' } ) => {
-  const mongoQuery = JSON.stringify( formatMongoSearchQuery( tags, search ) );
+  const mongoQuery = JSON.stringify( formatMongoSearchQuery( { tags, search } ) );
   const response = await fetch( `${ apiBase }Item/?limit=${ limit }&skip=${ skip }&sort={"originated":-1}&query=${ mongoQuery }` );
   return response.json();
 }
 
 const fetchShuffledItems = async ( { limit = 1, skip = 0, tags = [], search = '' } ) => {
-  const mongoQuery = JSON.stringify( formatMongoSearchQuery( tags, search ) );
+  const mongoQuery = JSON.stringify( formatMongoSearchQuery( { tags, search } ) );
   const response = await fetch( `${ apiBase }lucky/?limit=${ limit }&skip=${ skip }&sort={"originated":-1}&query=${ mongoQuery }` );
   return response.json();
 }

--- a/src/style/App.scss
+++ b/src/style/App.scss
@@ -6,7 +6,7 @@ $heading-font-size: 2em;
 $font-size: 1.2em;
 
 body {
-  background-color: $background;
+  background-color: $header-bg;
   color: $text;
   overflow-wrap: break-word;
 }
@@ -195,6 +195,7 @@ button:active {
 }
 
 .app > .tags {
+  background: $colour-c;
   padding: $margin;
 }
 


### PR DESCRIPTION
Browsing by tags is fun, and is really part of the nav - it should be at the top.

In this PR the tag cloud is moved to the top. 

The full tag cloud is slow to load & render, so there's now a limit of 250 tags, which is good for browsing yet still loads quickly and doesn't use up too much vertical space.

The style and colours for the tag cloud have also been tweaked.

Screenshot, using new Alcatraz colour scheme:

<img width="1727" alt="Screen Shot 2020-05-19 at 7 33 23 PM" src="https://user-images.githubusercontent.com/4167300/82298025-9e546100-9a07-11ea-9fe4-21f0f3ba9063.png">
