### PR TITLE
edit (with autosave) & done flow + adopt Material-UI, tweak theme/styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14297,6 +14297,11 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
+    "use-debounce": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-3.4.2.tgz",
+      "integrity": "sha512-rW44wZaFPh3XiwUzGBA0JRuklpbfKO/szU/5CYD2Q/erLmCem63lJ650p3a+NJE6S+g0rulKtBOfa/3rw/GN+Q=="
+    },
     "util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "react-mde": "10.0.3",
     "react-redux": "7.2.0",
     "react-router-dom": "5.2.0",
-    "react-scripts": "3.4.1"
+    "react-scripts": "3.4.1",
+    "use-debounce": "3.4.2"
   },
   "scripts": {
     "docker:start": "docker-compose up -d",

--- a/src/App.js
+++ b/src/App.js
@@ -42,15 +42,7 @@ import Editor from './components/Editor';
 
 import './style/App.scss';
 
-const theme = createMuiTheme( {
-  typography: {
-    fontFamily: [ 'Roboto', 'Helvetica', 'Arial', 'sans-serif' ],
-    button: {
-      textTransform: 'none',
-    }
-  },
-} );
-
+import themeConfig from './style/mui-theme-config';
 
 function useQuery() {
   return new URLSearchParams( useLocation().search );
@@ -156,12 +148,14 @@ function HydratedListView() {
   return ( <ListView /> );
 }
 
+const muiTheme = createMuiTheme( themeConfig );
+
 function App() {
 
   return (
     <Router>
       <Provider store={ store }>
-        <ThemeProvider theme={theme}>
+        <ThemeProvider theme={ muiTheme }>
           <CssBaseline />
           <Navigation />
 

--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,9 @@ import {
   useParams,
 } from 'react-router-dom';
 
+import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import CssBaseline from '@material-ui/core/CssBaseline';
+
 import {
   setPagination,
   setFilterTags,
@@ -38,6 +41,16 @@ import Editor from './components/Editor';
 
 
 import './style/App.scss';
+
+const theme = createMuiTheme( {
+  typography: {
+    fontFamily: [ 'Roboto', 'Helvetica', 'Arial', 'sans-serif' ],
+    button: {
+      textTransform: 'none',
+    }
+  },
+} );
+
 
 function useQuery() {
   return new URLSearchParams( useLocation().search );
@@ -148,25 +161,28 @@ function App() {
   return (
     <Router>
       <Provider store={ store }>
-        <Navigation />
+        <ThemeProvider theme={theme}>
+          <CssBaseline />
+          <Navigation />
 
-        <Switch>
-          <Route path="/wurd" children={ 
-            <RandomWurdView />
-          } />
-          <Route path="/item/:id" children={ 
-            <HydratedArticleView />
-          } />
-          <Route path="/edit/:id" children={ 
-            <HydratedEditorView />
-          } />
-          <Route path="/lucky" children={ 
-            <HydratedShuffleView />
-          } />
-          <Route path="/" children={ 
-            <HydratedListView />
-          } />
-        </Switch>
+          <Switch>
+            <Route path="/wurd" children={ 
+              <RandomWurdView />
+            } />
+            <Route path="/item/:id" children={ 
+              <HydratedArticleView />
+            } />
+            <Route path="/edit/:id" children={ 
+              <HydratedEditorView />
+            } />
+            <Route path="/lucky" children={ 
+              <HydratedShuffleView />
+            } />
+            <Route path="/" children={ 
+              <HydratedListView />
+            } />
+          </Switch>
+        </ThemeProvider>
       </Provider>
     </Router>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -57,7 +57,7 @@ function HydratedEditorView() {
   }, [ id ] );
 
   return (
-    <div className='app editor'>
+    <div className='app'>
       <Editor />
     </div>
   );

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -89,7 +89,15 @@ function Editor () {
           value={ tags }
           onChange={ event => onChange( setTags, event.target.value ) }
         />
-        <Button component={ Link } to={ articleUrl( item._id ) } disabled={ dirty || saving }>Done</Button>
+        <Button 
+          variant='contained' 
+          color='primary'
+          component={ Link } 
+          to={ articleUrl( item._id ) } 
+          disabled={ dirty || saving }
+        >
+          Done
+        </Button>
       </>
   );
 }

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -9,9 +9,10 @@ import { useDebouncedCallback } from 'use-debounce';
 import ReactMde from 'react-mde';
 import 'react-mde/lib/styles/scss/react-mde-all.scss';
 
-import { getArticle } from '../store/article/selectors';
+import { getArticle, isDirty, isSaving } from '../store/article/selectors';
 import {
   persistArticle,
+  setDirty, 
 } from '../store/article/actions';
 import store from '../store';
 
@@ -20,6 +21,8 @@ import { articleUrl } from '../lib/route-url';
 
 function Editor () {
   const item = useSelector( getArticle );
+  const dirty = useSelector( isDirty );
+  const saving = useSelector( isSaving );
 
   // Store the edited item content in local state.
   const [ title, setTitle ] = React.useState( false );
@@ -54,6 +57,7 @@ function Editor () {
   // - save new value in local state, using a setState func
   // - trigger a debounced update
   const onChange = ( setStateFunc, value ) => {
+    store.dispatch( setDirty( true ) );
     setStateFunc( value );
     debouncedSave(); 
   }
@@ -85,7 +89,7 @@ function Editor () {
           value={ tags }
           onChange={ event => onChange( setTags, event.target.value ) }
         />
-        <Button component={ Link } to={ articleUrl( item._id ) }>Done</Button>
+        <Button component={ Link } to={ articleUrl( item._id ) } disabled={ dirty || saving }>Done</Button>
       </>
   );
 }

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -65,44 +65,46 @@ function Editor () {
 
   const [ selectedTab, setSelectedTab ] = React.useState("write");
   return (
-      <>
-        <ReactMde
-          classes={{ reactMde: 'editor-title' }}
-          value={ title }
-          disablePreview={ true }
-          toolbarCommands={ [] }
-          minEditorHeight={ 58 }
-          maxEditorHeight={ 58 }
-          onChange={ onChange.bind( null, setTitle ) }
-        />
-        <ReactMde
-          classes={{ reactMde: 'editor-content' }}
-          value={ content }
-          onChange={ onChange.bind( null, setContent ) }
-          selectedTab={ selectedTab }
-          onTabChange={ setSelectedTab }
-          generateMarkdownPreview={ markdown =>
-            Promise.resolve( markdownRenderer( markdown ) )
-          }
-        />
-        <textarea 
-          className='editor-tags'
-          value={ tags }
-          onChange={ event => onChange( setTags, event.target.value ) }
-        />
-        <div className='toolbar article-toolbar'>
-          <Button 
-            variant='contained' 
-            color='primary'
-            startIcon={ <DoneIcon /> }
-            component={ Link } 
-            to={ articleUrl( item._id ) } 
-            disabled={ dirty || saving }
-          >
-            Done
-          </Button>
-        </div>
-      </>
+    <>
+    <div className='editor'>
+      <ReactMde
+        classes={{ reactMde: 'editor-title' }}
+        value={ title }
+        disablePreview={ true }
+        toolbarCommands={ [] }
+        minEditorHeight={ 58 }
+        maxEditorHeight={ 58 }
+        onChange={ onChange.bind( null, setTitle ) }
+      />
+      <ReactMde
+        classes={{ reactMde: 'editor-content' }}
+        value={ content }
+        onChange={ onChange.bind( null, setContent ) }
+        selectedTab={ selectedTab }
+        onTabChange={ setSelectedTab }
+        generateMarkdownPreview={ markdown =>
+          Promise.resolve( markdownRenderer( markdown ) )
+        }
+      />
+      <textarea 
+        className='editor-tags'
+        value={ tags }
+        onChange={ event => onChange( setTags, event.target.value ) }
+      />
+    </div>
+      <div className='toolbar article-toolbar'>
+        <Button 
+          variant='contained' 
+          color='primary'
+          startIcon={ <DoneIcon /> }
+          component={ Link } 
+          to={ articleUrl( item._id ) } 
+          disabled={ dirty || saving }
+        >
+          Done
+        </Button>
+      </div>
+    </>
   );
 }
 

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -1,5 +1,8 @@
 import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
+import { Link } from 'react-router-dom';
+
+import Button from '@material-ui/core/Button';
 
 import ReactMde from 'react-mde';
 import 'react-mde/lib/styles/scss/react-mde-all.scss';
@@ -11,7 +14,7 @@ import {
 import store from '../store';
 
 import markdownRenderer from '../lib/markdown-renderer';
-
+import { articleUrl } from '../lib/route-url';
 
 function Editor () {
   const item = useSelector( getArticle );
@@ -66,7 +69,8 @@ function Editor () {
           value={ tags }
           onChange={ event => setTags( event.target.value ) }
         />
-        <button className='editor-save' onClick={ save }>Save</button>
+        <Button onClick={ save }>Save</Button>
+        <Button component={ Link } to={ articleUrl( item._id ) }>Done</Button>
       </>
   );
 }

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 
 import Button from '@material-ui/core/Button';
+import DoneIcon from '@material-ui/icons/Done';
 
 import { useDebouncedCallback } from 'use-debounce';
 
@@ -89,15 +90,18 @@ function Editor () {
           value={ tags }
           onChange={ event => onChange( setTags, event.target.value ) }
         />
-        <Button 
-          variant='contained' 
-          color='primary'
-          component={ Link } 
-          to={ articleUrl( item._id ) } 
-          disabled={ dirty || saving }
-        >
-          Done
-        </Button>
+        <div className='toolbar article-toolbar'>
+          <Button 
+            variant='contained' 
+            color='primary'
+            startIcon={ <DoneIcon /> }
+            component={ Link } 
+            to={ articleUrl( item._id ) } 
+            disabled={ dirty || saving }
+          >
+            Done
+          </Button>
+        </div>
       </>
   );
 }

--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 
 import Button from '@material-ui/core/Button';
+import EditIcon from '@material-ui/icons/Edit';
 
 import markdownRenderer from '../lib/markdown-renderer';
 import { editArticleUrl } from '../lib/route-url';
@@ -25,10 +26,11 @@ function Item() {
         }} /> 
         <TagList tags={ item.tags } /> 
       </div> 
-      <div className='article-toolbar'>
+      <div className='toolbar article-toolbar'>
         <Button 
           variant='contained' 
           color='primary'
+          startIcon={ <EditIcon /> }
           component={ Link }
           to={ editArticleUrl( item._id ) }
         >

--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -26,7 +26,14 @@ function Item() {
         <TagList tags={ item.tags } /> 
       </div> 
       <div className='article-toolbar'>
-        <Button component={ Link } to={ editArticleUrl( item._id ) }>Edit</Button>
+        <Button 
+          variant='contained' 
+          color='primary'
+          component={ Link }
+          to={ editArticleUrl( item._id ) }
+        >
+          Edit
+        </Button>
       </div>
     </>
   );

--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
+import { Link } from 'react-router-dom';
 
 import Button from '@material-ui/core/Button';
 
 import markdownRenderer from '../lib/markdown-renderer';
+import { editArticleUrl } from '../lib/route-url';
 
 import { getArticle } from '../store/article/selectors';
 
@@ -24,7 +26,7 @@ function Item() {
         <TagList tags={ item.tags } /> 
       </div> 
       <div className='article-toolbar'>
-        <Button>Edit</Button>
+        <Button component={ Link } to={ editArticleUrl( item._id ) }>Edit</Button>
       </div>
     </>
   );

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -9,7 +9,7 @@ import Shuffle from './Shuffle';
 
 function Navigation() {
   return (
-    <div className='navigation'>
+    <div className='toolbar navigation'>
       <Link className='home' to='/'><ApartmentIcon className='icon' /></Link>
       <Search />
       <Shuffle />

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -10,7 +10,7 @@ import Shuffle from './Shuffle';
 function Navigation() {
   return (
     <div className='toolbar navigation'>
-      <Link className='home' to='/'><ApartmentIcon className='icon' /></Link>
+      <Link className='iconbutton home' to='/'><ApartmentIcon className='icon' /></Link>
       <Search />
       <Shuffle />
     </div>

--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -28,7 +28,7 @@ function Pagination() {
   const prevPage = params.toString();
 
   return (
-    <div className='pagination'>
+    <div className='toolbar pagination'>
       <Link className='previousPage' to={ `/?${ prevPage }` } ><ArrowBackIcon className='icon' /></Link>
       <Link className='nextPage' to={ `/?${ nextPage }` } ><ArrowForwardIcon className='icon' /></Link>
     </div>

--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -29,8 +29,8 @@ function Pagination() {
 
   return (
     <div className='toolbar pagination'>
-      <Link className='previousPage' to={ `/?${ prevPage }` } ><ArrowBackIcon className='icon' /></Link>
-      <Link className='nextPage' to={ `/?${ nextPage }` } ><ArrowForwardIcon className='icon' /></Link>
+      <Link className='iconbutton previousPage' to={ `/?${ prevPage }` } ><ArrowBackIcon className='icon' /></Link>
+      <Link className='iconbutton nextPage' to={ `/?${ nextPage }` } ><ArrowForwardIcon className='icon' /></Link>
     </div>
   );
 }

--- a/src/lib/route-url.js
+++ b/src/lib/route-url.js
@@ -1,3 +1,7 @@
+/**
+  Utility functions for generating urls to app routes.
+ */
+
 
 export function listUrl( { tags, search, shuffle } ) {
   const params = new URLSearchParams();
@@ -16,4 +20,8 @@ export function listUrl( { tags, search, shuffle } ) {
 
 export function articleUrl( id ) {
   return `/item/${ id }`;
+}
+
+export function editArticleUrl( id ) {
+  return `/edit/${ id }`;
 }

--- a/src/store/article/actions.js
+++ b/src/store/article/actions.js
@@ -8,6 +8,10 @@ export const setId = createAction( 'article/setArticleId' );
 
 export const articleReceived = createAction( 'article/itemsReceived' );
 
+export const setSaving = createAction( 'article/setSaving' );
+
+export const setDirty = createAction( 'article/setDirty' );
+
 const fetchArticle = async ( { id } ) => {
   const response = await fetch( `${ apiBase }Item/${ id }` );
   return response.json();
@@ -21,7 +25,8 @@ export const hydrateArticle = () => async ( dispatch, state ) => {
 }
 
 export const persistArticle = ( { id, title, content, userTags }  ) => async ( dispatch, state ) => {
-  // todo set "saving" flag
+  dispatch( setSaving( true ) );
+  dispatch( setDirty( false ) );
 
   const current = getArticle( state() )
   const newArticle = { 
@@ -41,5 +46,8 @@ export const persistArticle = ( { id, title, content, userTags }  ) => async ( d
   // const response = await fetchArticle( { id } );
   // dispatch( articleReceived( response ) );
 
-  // todo reset "saving" flag
+  // todo handle errors
+  // if error, setDirty( true ) again
+
+  dispatch( setSaving( false ) );
 }

--- a/src/store/article/actions.js
+++ b/src/store/article/actions.js
@@ -35,19 +35,25 @@ export const persistArticle = ( { id, title, content, userTags }  ) => async ( d
     content,
     userTags,
   };
-  await fetch( `${ apiBase }Item/${ id }`, {
-    method: 'PATCH',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify( newArticle ),
-  } );
+  try {  
+    const response = await fetch( `${ apiBase }Item/${ id }`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify( newArticle ),
+    } );
+    if ( 200 !== response.status ) {
+      dispatch( setDirty( true ) );
+    }
+  }
+  catch ( error ) {
+    // If save failed, then we're dirty again.
+    dispatch( setDirty( true ) );
+  }
   // update - various derived fields may have changed
   // const response = await fetchArticle( { id } );
   // dispatch( articleReceived( response ) );
-
-  // todo handle errors
-  // if error, setDirty( true ) again
 
   dispatch( setSaving( false ) );
 }

--- a/src/store/article/reducer.js
+++ b/src/store/article/reducer.js
@@ -5,6 +5,8 @@ import * as actions from './actions';
 const DEFAULT_STATE = {
   id: '',
   article: {},
+  isSaving: false,
+  isDirty: false,
 };
 
 const reducer = createReducer( DEFAULT_STATE, {
@@ -13,6 +15,12 @@ const reducer = createReducer( DEFAULT_STATE, {
   },
   [ actions.setId ]: ( state, action ) => {
     state.id = action.payload;
+  },
+  [ actions.setSaving ]: ( state, action ) => {
+    state.isSaving = action.payload;
+  },
+  [ actions.setDirty ]: ( state, action ) => {
+    state.isDirty = action.payload;
   },
 } );
 

--- a/src/store/article/selectors.js
+++ b/src/store/article/selectors.js
@@ -2,3 +2,7 @@
 export const getId = state => state.article.id;
 
 export const getArticle = state => state.article.article;
+
+export const isDirty = state => state.article.isDirty;
+
+export const isSaving = state => state.article.isSaving;

--- a/src/style/App.scss
+++ b/src/style/App.scss
@@ -1,5 +1,7 @@
 @import './Colours.scss';
 
+@import url(http://fonts.googleapis.com/css?Roboto:400,400italic,700italic,700);
+
 $margin: 2em;
 $header-icon-size: 50px;
 $heading-font-size: 2em;

--- a/src/style/App.scss
+++ b/src/style/App.scss
@@ -59,11 +59,11 @@ button:active {
   padding: 1em $margin;
   background: $header-bg;
 
-  // a, a:visited {
-  //   color: $link;
-  //   text-decoration: none;
-  //   font-weight: 500;
-  // }
+  a.iconbutton , a.iconbutton :visited {
+    color: $link;
+    text-decoration: none;
+    font-weight: 500;
+  }
 }
 
 .navigation {

--- a/src/style/App.scss
+++ b/src/style/App.scss
@@ -1,11 +1,14 @@
 @import './Colours.scss';
 
-@import url(http://fonts.googleapis.com/css?Roboto:400,400italic,700italic,700);
+@import url('https://fonts.googleapis.com/css2?family=Inconsolata&family=Merriweather+Sans:ital,wght@0,300;0,400;0,800;1,300;1,400;1,700&display=swap');
 
 $margin: 2em;
 $header-icon-size: 50px;
 $heading-font-size: 2em;
 $font-size: 1.2em;
+
+$font-body: 'Merriweather', sans-serif;
+$font-editor: 'Inconsolata', monospace;
 
 body {
   background-color: $header-bg;
@@ -173,6 +176,10 @@ button:active {
 
 .editor {
   background-color: $colour-b;
+
+  textarea.mde-text {
+    font-family: $font-editor;
+  }
 }
 
 .article:nth-child(even) {

--- a/src/style/App.scss
+++ b/src/style/App.scss
@@ -17,12 +17,6 @@ pre {
   white-space: pre-wrap;
 }
 
-a, a:visited {
-  color: $link;
-  text-decoration: none;
-  font-weight: 500;
-}
-
 // reset search input
 input[type=search] {
   -webkit-appearance: textfield;
@@ -59,12 +53,20 @@ button:active {
     transform: scale(0.99);
 }
 
-.navigation {
+.toolbar {
   display: flex;
   justify-content: space-between;
   padding: 1em $margin;
   background: $header-bg;
 
+  // a, a:visited {
+  //   color: $link;
+  //   text-decoration: none;
+  //   font-weight: 500;
+  // }
+}
+
+.navigation {
   > * {
     display: inline-flex;
   }
@@ -180,6 +182,12 @@ button:active {
 
   h1, h2, h3, h4, h5, h6 {
     margin: 0.5em 0 1em;
+  }
+
+  a, a:visited {
+    color: $link;
+    text-decoration: none;
+    font-weight: 500;
   }
 
   .content {

--- a/src/style/App.scss
+++ b/src/style/App.scss
@@ -66,6 +66,10 @@ button:active {
   }
 }
 
+.article-toolbar {
+  justify-content: flex-end;
+}
+
 .navigation {
   > * {
     display: inline-flex;

--- a/src/style/App.scss
+++ b/src/style/App.scss
@@ -167,6 +167,10 @@ button:active {
   padding: 1em $margin;
 }
 
+.editor {
+  background-color: $colour-b;
+}
+
 .article:nth-child(even) {
   background-color: $colour-c;
 }

--- a/src/style/mui-theme-config.js
+++ b/src/style/mui-theme-config.js
@@ -1,0 +1,23 @@
+
+
+const theme = {
+  palette: {
+    primary: {
+      main: '#3a1c01',
+      contrastText: '#d2c2bc',
+    },
+  },
+  shape: {
+    borderRadius: 2,
+  },
+  typography: {
+    fontFamily: [ 'Roboto', 'Helvetica', 'Arial', 'sans-serif' ],
+    button: {
+      textTransform: 'none',
+
+    }
+  },
+};
+
+
+export default theme;

--- a/src/style/mui-theme-config.js
+++ b/src/style/mui-theme-config.js
@@ -14,7 +14,7 @@ const theme = {
     borderRadius: 2,
   },
   typography: {
-    fontFamily: [ 'Roboto', 'Helvetica', 'Arial', 'sans-serif' ],
+    fontFamily: [ 'Merriweather', 'sans-serif' ],
     button: {
       textTransform: 'none',
     }

--- a/src/style/mui-theme-config.js
+++ b/src/style/mui-theme-config.js
@@ -2,6 +2,9 @@
 
 const theme = {
   palette: {
+    background: {
+      default: '#a00000',
+    },
     primary: {
       main: '#3a1c01',
       contrastText: '#d2c2bc',
@@ -14,7 +17,6 @@ const theme = {
     fontFamily: [ 'Roboto', 'Helvetica', 'Arial', 'sans-serif' ],
     button: {
       textTransform: 'none',
-
     }
   },
 };


### PR DESCRIPTION
This PR adopts [Material-UI lib](https://material-ui.com/). Initially I'm using this to standardise buttons and express the style/theme of the app as a Material UI theme (this is in progress - will adopt more incrementally in future).

Feature wise this PR has buttons for editing an article and returning to the article view when done. In the editor, the content is autosaved in the background - there's no "save".