### PR TITLE
Allow adding new item from list view

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,6 +12,9 @@ import {
 import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
 
+import Fab from '@material-ui/core/Fab';
+import AddIcon from '@material-ui/icons/Add';
+
 import {
   setPagination,
   setFilterTags,
@@ -43,6 +46,8 @@ import Editor from './components/Editor';
 import './style/App.scss';
 
 import themeConfig from './style/mui-theme-config';
+
+const muiTheme = createMuiTheme( themeConfig );
 
 function useQuery() {
   return new URLSearchParams( useLocation().search );
@@ -94,11 +99,16 @@ function HydratedArticleView() {
 
 function ListView() {
   return (
-    <div className='app'>
-      <TagCloud />
-      <Items />
-      <Pagination />
-    </div>
+    <>
+      <Fab color="primary" aria-label="add">
+        <AddIcon />
+      </Fab>
+      <div className='app'>
+        <TagCloud />
+        <Items />
+        <Pagination />
+      </div>
+    </>
    );
 }
 
@@ -147,8 +157,6 @@ function HydratedListView() {
 
   return ( <ListView /> );
 }
-
-const muiTheme = createMuiTheme( themeConfig );
 
 function App() {
 

--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,14 @@
 
 import React, { useEffect } from 'react';
-import { Provider } from 'react-redux';
+import {
+  Provider,
+  useSelector,
+} from 'react-redux';
 import {
   BrowserRouter as Router,
   Switch,
   Route,
+  Redirect,
   useLocation,
   useParams,
 } from 'react-router-dom';
@@ -30,7 +34,10 @@ import {
 import {
   setId,
   hydrateArticle,
+  newArticle,
 } from './store/article/actions';
+
+import { getRedirect } from './store/app/selectors';
 
 import store from './store';
 
@@ -96,11 +103,25 @@ function HydratedArticleView() {
   return ( <ArticleView /> );
 }
 
+function Redirector() {
+  const redirectUrl = useSelector( getRedirect );
+  return redirectUrl ? ( <Redirect to={ redirectUrl } /> ) : null;
+}
 
 function ListView() {
   return (
     <>
-      <Fab color="primary" aria-label="add">
+      <Fab
+        color='primary'
+        aria-label='add'
+        onClick={ () => store.dispatch( newArticle( {
+          userTags: 'test bla',
+          // We need to supply these - there's no defaults!
+          // TODO add defaults on server
+          title: '',
+          content: '',
+        } ) ) }
+      >
         <AddIcon />
       </Fab>
       <div className='app'>
@@ -163,6 +184,7 @@ function App() {
   return (
     <Router>
       <Provider store={ store }>
+        <Redirector />
         <ThemeProvider theme={ muiTheme }>
           <CssBaseline />
           <Navigation />

--- a/src/App.js
+++ b/src/App.js
@@ -37,6 +37,8 @@ import {
   newArticle,
 } from './store/article/actions';
 
+import { getFilter } from './store/list/selectors';
+
 import { getRedirect } from './store/app/selectors';
 
 import store from './store';
@@ -109,13 +111,14 @@ function Redirector() {
 }
 
 function ListView() {
+  const { tags: filterTags } = useSelector( getFilter );
   return (
     <>
       <Fab
         color='primary'
         aria-label='add'
         onClick={ () => store.dispatch( newArticle( {
-          userTags: 'test bla',
+          userTags: filterTags.join( ' ' ),
           // We need to supply these - there's no defaults!
           // TODO add defaults on server
           title: '',

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -33,13 +33,13 @@ function Editor () {
   // The item is loaded dynamically after we are mounted; 
   // populate the state after load.
   useEffect( () => {
-    if ( item.title && false === title ) {
+    if ( item.hasOwnProperty( 'title' ) && false === title ) {
       setTitle( item.title );
     }
-    if ( item.content && false === content ) {
+    if ( item.hasOwnProperty( 'content' ) && false === content ) {
       setContent( item.content );
     }
-    if ( item.userTags && false === tags ) {
+    if ( item.hasOwnProperty( 'userTags' ) && false === tags ) {
       setTags( item.userTags );
     }
   }, [ item, title, content, tags ] );

--- a/src/server/models/item.js
+++ b/src/server/models/item.js
@@ -327,7 +327,6 @@ schema.methods.generateOriginatedDateFromTags = function() {
 };
 
 schema.methods.setImportDateNow = function() {
-   var item = this;
    this.imported = Date.now();
 };
 
@@ -338,7 +337,7 @@ schema.methods.normalise = function() {
       this.title = generateTitle( item );
 
    // system-managed fields
-   this.tags.push( ...indexHashtags(item) );
+   this.tags = indexHashtags(item);
    this.lowerCaseTags = _.map( this.tags, tag => tag.toLowerCase() );
    this.textContent = generateTextContent( item );
 };

--- a/src/server/models/item.js
+++ b/src/server/models/item.js
@@ -29,11 +29,11 @@ function generateTitle(item) {
    return title;
 };
 
-function generateTextContent(item) {
+function generateTextContent( item ) {
    var textContent = '';
    var renderer = new PlainTextRenderer();
-   textContent += ' ' + marked(item.content, { renderer: renderer });
-   textContent += ' ' + marked(item.title, { renderer: renderer });
+   textContent += ' ' + marked( item.content || '', { renderer: renderer } );
+   textContent += ' ' + marked( item.title || '', { renderer: renderer } );
    return textContent;
 };
 
@@ -334,20 +334,19 @@ schema.methods.setImportDateNow = function() {
 
 schema.methods.normalise = function() {
    var item = this;
-   if (!this.title)
-      this.title = generateTitle(item);
+   if ( ! this.title )
+      this.title = generateTitle( item );
 
    // system-managed fields
-   this.tags = indexHashtags(item);
-   this.lowerCaseTags = _.map(this.tags, tag => tag.toLowerCase());
-   this.textContent = generateTextContent(item);
+   this.tags.push( ...indexHashtags(item) );
+   this.lowerCaseTags = _.map( this.tags, tag => tag.toLowerCase() );
+   this.textContent = generateTextContent( item );
 };
 
 // Once only (i.e. when importing) we need to extract tags from context.
 // We put these in userTags so they user can tweak them as needed or use as-is.
 // Note that normalise() (above) processes userTags, so this should be run first.
 schema.methods.importContextTags = function() {
-   var item = this;
    this.userTags = appendTagsFromContext(this.context, this.userTags);
 };
 

--- a/src/server/models/item.js
+++ b/src/server/models/item.js
@@ -280,6 +280,8 @@ function extractTagCreatedDate(item) {
          case 'dec':
             itemCreatedEstimate.setMonth(11);
             break;
+         default: 
+            break;
       }
 
       const rxYearMonthDay = /(\d\d\d\d)(\d\d)(\d\d)/;

--- a/src/store/app/actions.js
+++ b/src/store/app/actions.js
@@ -1,0 +1,4 @@
+import { createAction } from '@reduxjs/toolkit';
+
+export const redirect = createAction( 'app/redirect' );
+

--- a/src/store/app/reducer.js
+++ b/src/store/app/reducer.js
@@ -1,0 +1,16 @@
+import { createReducer } from '@reduxjs/toolkit';
+
+import * as actions from './actions';
+
+const DEFAULT_STATE = {
+  // set to a route url to trigger a redirect
+  redirect: '',
+};
+
+const reducer = createReducer( DEFAULT_STATE, {
+  [ actions.redirect ]: ( state, action ) => {
+    state.redirect = action.payload;
+  },
+} );
+
+export default reducer;

--- a/src/store/app/selectors.js
+++ b/src/store/app/selectors.js
@@ -1,0 +1,2 @@
+
+export const getRedirect = state => state.app.redirect;

--- a/src/store/app/store.js
+++ b/src/store/app/store.js
@@ -1,0 +1,7 @@
+import { configureStore } from '@reduxjs/toolkit';
+
+import rootReducer from './reducer';
+
+const store = configureStore( { reducer: rootReducer } );
+
+export default store;

--- a/src/store/article/actions.js
+++ b/src/store/article/actions.js
@@ -44,6 +44,7 @@ export const newArticle = ( { title, content, userTags }  ) => async ( dispatch,
     if ( 200 !== response.status ) {
     }
     const item = await response.json();
+    dispatch( articleReceived( item ) );
     dispatch( redirect( editArticleUrl( item._id ) ) );
   }
   catch ( error ) {

--- a/src/store/article/actions.js
+++ b/src/store/article/actions.js
@@ -1,12 +1,15 @@
 import { createAction } from '@reduxjs/toolkit';
 
 import { apiBase } from '../../lib/api';
+import { editArticleUrl } from '../../lib/route-url';
+
+import { redirect } from '../app/actions';
 
 import { getId, getArticle } from './selectors';
 
 export const setId = createAction( 'article/setArticleId' );
 
-export const articleReceived = createAction( 'article/itemsReceived' );
+export const articleReceived = createAction( 'article/itemReceived' );
 
 export const setSaving = createAction( 'article/setSaving' );
 
@@ -22,6 +25,30 @@ export const hydrateArticle = () => async ( dispatch, state ) => {
   const id = getId( current );
   const response = await fetchArticle( { id } );
   dispatch( articleReceived( response ) );
+}
+
+export const newArticle = ( { title, content, userTags }  ) => async ( dispatch, state ) => {
+  const newArticle = { 
+    title, 
+    content,
+    userTags,
+  };
+  try {  
+    const response = await fetch( `${ apiBase }Item`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify( newArticle ),
+    } );
+    if ( 200 !== response.status ) {
+    }
+    const item = await response.json();
+    dispatch( redirect( editArticleUrl( item._id ) ) );
+  }
+  catch ( error ) {
+  }
+
 }
 
 export const persistArticle = ( { id, title, content, userTags }  ) => async ( dispatch, state ) => {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,3 +1,4 @@
+import app from './app/reducer';
 import list from './list/reducer';
 import article from './article/reducer';
 
@@ -5,6 +6,7 @@ import { configureStore } from '@reduxjs/toolkit';
 
 const store = configureStore( { 
   reducer: {
+    app,
     list,
     article,
   } 

--- a/src/style/App.scss
+++ b/src/style/App.scss
@@ -1,4 +1,5 @@
 @import './Colours.scss';
+@import './Material-UI.scss';
 
 @import url('https://fonts.googleapis.com/css2?family=Inconsolata&family=Merriweather+Sans:ital,wght@0,300;0,400;0,800;1,300;1,400;1,700&display=swap');
 

--- a/src/style/Material-UI.scss
+++ b/src/style/Material-UI.scss
@@ -1,0 +1,7 @@
+
+.MuiButtonBase-root.MuiFab-root {
+  position: absolute;
+  bottom: 1.5em;
+  right: 1.5em;
+}
+


### PR DESCRIPTION
Big "add" material FAB on list view. POSTs a new item and navigates to editing it. If there is a current tag filter then those tags are added to the new item - so you can add a similar tagged item easily.

This PR changes the importer/item model slightly - there are defaults (empty string) for `title` and `textContent`. Will probably do some more testing of importer/parser and fix some existing issues before deploying.

