### PR TITLE
Switch to more robust hashtag parser - attempt 2

### DIFF
--- a/EditorConfig.txt
+++ b/EditorConfig.txt
@@ -1,0 +1,16 @@
+# EditorConfig is awesome: http://editorconfig.org
+# save this as .editorconfig at root of whatever project
+
+root = true
+
+[*]
+end_of_line = lf
+indent_style = space
+indent_size = 2
+charset = utf-8
+
+[*.md]
+indent_size = 2
+ 
+[package.json]
+indent_size = 2

--- a/package-lock.json
+++ b/package-lock.json
@@ -6578,10 +6578,10 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
-    "hashtag": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/hashtag/-/hashtag-0.0.1.tgz",
-      "integrity": "sha1-0UPvhj9C1MMh1Bo/ZNw8C0uodEo="
+    "hashtag-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hashtag-regex/-/hashtag-regex-2.1.0.tgz",
+      "integrity": "sha512-D89pGyCZOMtaXdEJ1he9/GmhZAUXlHPn+oN2oFmrNZFX9MlblUdqw7DmJ2IlWc1My+GP0BeCDlMwWW2zSVLVoA=="
     },
     "he": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8993,9 +8993,9 @@
       }
     },
     "marked": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-1.1.0.tgz",
-      "integrity": "sha512-EkE7RW6KcXfMHy2PA7Jg0YJE1l8UPEZE8k45tylzmZM30/r1M1MUXWQfJlrSbsTeh7m/XTwHbWUENvAJZpp1YA=="
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
+      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw=="
     },
     "marked-plaintext": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "express-restify-mongoose": "6.0.0",
     "hashtag-regex": "^2.1.0",
     "lodash": "4.17.15",
-    "marked": "1.1.0",
+    "marked": "0.8.2",
     "marked-plaintext": "0.0.2",
     "method-override": "3.0.0",
     "moment": "2.27.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "connect-history-api-fallback": "1.6.0",
     "express": "4.17.1",
     "express-restify-mongoose": "6.0.0",
-    "hashtag": "0.0.1",
+    "hashtag-regex": "^2.1.0",
     "lodash": "4.17.15",
     "marked": "1.1.0",
     "marked-plaintext": "0.0.2",
@@ -34,6 +34,7 @@
   "scripts": {
     "docker:start": "docker-compose up -d",
     "import": "node src/server/scripts/import",
+    "normalise": "node src/server/scripts/normalise-db",
     "start": "BROWSER=none react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,9 +1,0 @@
-import React from 'react';
-import { render } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  const { getByText } = render(<App />);
-  const linkElement = getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/src/lib/markdown-renderer.js
+++ b/src/lib/markdown-renderer.js
@@ -1,7 +1,7 @@
 // utilities for rendering markdown to html, including generating hashtag links
 
 import marked from 'marked';
-import hashtag from 'hashtag';
+import hashtagRegex from 'hashtag-regex';
 
 import { listUrl } from './route-url';
 
@@ -9,26 +9,19 @@ import { listUrl } from './route-url';
 // (so they are more readable in flowing text) 
 // or converting to a link.
 function processHashtags( md, asLinks = true ) {
-   let expandedMd = md;
+  if ( ! md ) { return; }
 
-   const hashtags = hashtag.parse(md);
-   const parserElements = hashtags.tokens;
+  const regex = hashtagRegex();
+  
+  const expandedMd = md.replace( regex, ( htag ) => {
+    const tag = htag.slice( 1 );
+    if ( asLinks ) {
+      const url = listUrl( { tags: [ tag ] } );
+      return `[${ tag }](${ url })`;
+    }
 
-   parserElements.map(element => {
-      if ( element.type === 'text' ) {
-         return element;
-      }
-      const url = listUrl( { tags: [ element.tag ] } );
-      element.text = element.tag;
-      if ( asLinks ) {
-         element.text = `[${ element.tag }](${ url })`;
-      }
-      return element;
-   });
-
-   expandedMd = parserElements.reduce( ( memo, element ) => {
-      return memo + element.text;
-   }, '' );
+    return tag;
+  } );
 
    return expandedMd;
 };

--- a/src/server/scripts/normalise-db.js
+++ b/src/server/scripts/normalise-db.js
@@ -4,9 +4,9 @@
 
 import mongoose from 'mongoose';
 
-import ItemModel from '../models/item';
+import ItemModel from '../models/item.js';
 
-import connectToDb from '../db/connection';
+import connectToDb from '../db/connection.js';
 let db = connectToDb();
 
 db.on('error', console.error.bind(console, 'connection error:'));
@@ -16,11 +16,29 @@ db.once('open', function() {
       let savePromises = [];
    
       items.forEach(item => {
-         item.importContextTags();
+         const oldTags = item.tags;
+         // in previous runs I've needed to regenerate tags from context
+         // now I just want to normalise
+         // item.importContextTags();
          // this is not needed explicitly;
          // as it's our pre save middleware (see `models/item`)
-         //item.normalise(); 
+         item.normalise(); 
          savePromises.push(item.save());
+         
+         const oldTagsStr = oldTags.join( ' ' );
+         const newTagsStr = item.tags.join( ' ' );
+         if ( item.tags.length > oldTags.length ) {
+            console.log( `😀 normalise added tags to item ${ item._id }:` );
+            console.log( `  ${ oldTagsStr }` );
+            console.log( `  ${ newTagsStr }` );
+            console.log( '' );
+         }
+         else if ( item.tags.length < oldTags.length ) {
+            console.log( `🧐 normalise LOST TAGS from item ${ item._id }:` );
+            console.log( `  ${ oldTagsStr }` );
+            console.log( `  ${ newTagsStr }` );
+            console.log( '' );
+         }
       });
 
       Promise.all(savePromises).then(function() {


### PR DESCRIPTION
Fixes #103 

Had to revert this - running `normalise-db` script removed more tags than it added. 

- Was running `normalise-db` on production data to reindex tags using new hashtag lib – i.e. to detect more hashtags, near punctuation etc.
- Debug output of the script indicated that bold/italic tags were getting lost in this process.

This PR aims to reinstate the new library and ensure bold/italics get indexed correctly.