### PR TITLE
fix add article button to window, not canvas

### DIFF
--- a/src/style/Material-UI.scss
+++ b/src/style/Material-UI.scss
@@ -1,6 +1,6 @@
 
 .MuiButtonBase-root.MuiFab-root {
-  position: absolute;
+  position: fixed;
   bottom: 1.5em;
   right: 1.5em;
 }


### PR DESCRIPTION
Fixes #146 

FAB was positioned `absolute` (to canvas); now `fixed` to window. The add article button now stays in the bottom right corner of window when scrolling or resizing.