### PR TITLE
handle no relatedTags in TagCloud

### DIFF
--- a/src/components/TagCloud.js
+++ b/src/components/TagCloud.js
@@ -50,7 +50,7 @@ function TagCloud() {
   const relatedTags = tags.filter( tag => {
     return ! filterTags.includes( tag.tag );
   } );
-  const maxHitCount = relatedTags[0].count;
+  const maxHitCount = relatedTags[0]?.count;
 
   const related = relatedTags.map( ( tag ) => {
     return ( 


### PR DESCRIPTION
Fixes #16 

When rendering the tag cloud, we use the count of the first (most popular) related tag to normalise the sizes of the other tags. Now this checks to handle the case when there are no relatedTags. 

Prevents fatal JS error when browsing deep in tags and you hit a combination of tags that matches a single article only.

To reproduce the original issue, keep clicking `+` related tags until there's only one, then click the last tag – this now shows a single article with all tags in the filter. Previously would crash.