### PR TITLE
Update marked lib, detect bold/italic tags at all levels and fix import issue with checkboxes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8675,9 +8675,9 @@
       }
     },
     "marked": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.1.1.tgz",
+      "integrity": "sha512-mJzT8D2yPxoPh7h0UXkB+dBj4FykPJ2OIfxAWeIHrvoHDkFxukV/29QxoFQoPM6RLEwhIFdJpmKBlqVM3s2ZIw=="
     },
     "marked-plaintext": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "express-restify-mongoose": "6.1.2",
     "hashtag-regex": "2.1.0",
     "lodash": "4.17.20",
-    "marked": "0.8.2",
+    "marked": "1.1.1",
     "marked-plaintext": "0.0.2",
     "method-override": "3.0.0",
     "moment": "2.28.0",

--- a/src/server/models/item.js
+++ b/src/server/models/item.js
@@ -84,38 +84,52 @@ function parseHashtags(md) {
 // entities are bold or italics, e.g. __Producer__ (bold) or *Work* (italics)
 // whitespace is collapsed (may revise this)
 function parseEntityTags(md) {
-   var tags = [];
-   var renderer = new marked.Renderer();
-   var strongs = [];
-   var ems = [];
-   renderer.strong = function(text) {
-      strongs.push(text);
-      return text;
-   }
-   renderer.em = function(text) {
-      ems.push(text);
-      return text;
+   if ( ! md ) {
+      return [];
    }
 
-   if (md) {
-      var tokens = marked.lexer(md);
-      _.each(tokens, token => {
-         // console.log(token);
-         if (token.text) {
-            marked(token.text, { renderer: renderer });
-         }
-      });
-      tags = strongs.concat(ems);
-      tags = tags.map(tag => {
-         var stripped = tag;
-         // strip html entities
-         stripped = stripped.replace(/&.+;/g, '');
-         // strip nonword chars
-         stripped = stripped.replace(/\W/g, '');
-         return stripped;
-      });
-      // console.log(tags);
-   }
+   let tags = [];
+
+   // Declare a renderer that simply accumulates all
+   // bold/italic token text in arrays.
+   let strongs = [];
+   let ems = [];
+   const renderer = {
+      strong: (text) => {
+         strongs.push(text);
+         return text;
+      },
+      em: (text) => {
+         ems.push(text);
+         return text;
+      }
+   };
+
+   // Split the markdown content into tokens.
+   // For each text token, parse and look for 
+   // bold/italic inline formatting.
+   const tokens = marked.lexer(md);
+   _.each(tokens, token => {
+      // console.log(token);
+      if (token.text) {
+         marked(token.text, { renderer: renderer });
+      }
+   });
+
+   // Single array of all bold/italic items => tags.
+   tags = strongs.concat(ems);
+
+   // Process each tag content to ensure is a single "word".
+   tags = tags.map(tag => {
+      let stripped = tag;
+      // strip html entities
+      stripped = stripped.replace(/&.+;/g, '');
+      // strip nonword chars
+      stripped = stripped.replace(/\W/g, '');
+      return stripped;
+   });
+   // console.log(tags);
+
    return tags;
 };
 

--- a/src/server/models/item.js
+++ b/src/server/models/item.js
@@ -32,6 +32,11 @@ function generateTitle(item) {
 function generateTextContent( item ) {
    var textContent = '';
    var renderer = new PlainTextRenderer();
+   // Patch `marked-plaintext` which does not yet support checkbox.
+   // Maybe should implement our own plain text renderer or submit a patch.
+   renderer.checkbox = ( text ) => {
+      return text;
+   }
    textContent += ' ' + marked( item.content || '', { renderer: renderer } );
    textContent += ' ' + marked( item.title || '', { renderer: renderer } );
    return textContent;

--- a/src/server/models/item.js
+++ b/src/server/models/item.js
@@ -90,31 +90,22 @@ function parseEntityTags(md) {
 
    let tags = [];
 
-   // Declare a renderer that simply accumulates all
-   // bold/italic token text in arrays.
+   // Hook walkTokens and if we see bold or italic anywhere in the tree,
+   // note down as a tag.
    let strongs = [];
    let ems = [];
-   const renderer = {
-      strong: (text) => {
-         strongs.push(text);
-         return text;
-      },
-      em: (text) => {
-         ems.push(text);
-         return text;
+   marked.use( { 
+      walkTokens: token => {
+         // console.log( token );
+         if ( token.type === 'em' ) {
+            strongs.push( token.text );
+         }
+         if ( token.type === 'strong' ) {
+            strongs.push( token.text );
+         }
       }
-   };
-
-   // Split the markdown content into tokens.
-   // For each text token, parse and look for 
-   // bold/italic inline formatting.
-   const tokens = marked.lexer(md);
-   _.each(tokens, token => {
-      // console.log(token);
-      if (token.text) {
-         marked(token.text, { renderer: renderer });
-      }
-   });
+    } );
+   marked(md);
 
    // Single array of all bold/italic items => tags.
    tags = strongs.concat(ems);
@@ -126,6 +117,7 @@ function parseEntityTags(md) {
       stripped = stripped.replace(/&.+;/g, '');
       // strip nonword chars
       stripped = stripped.replace(/\W/g, '');
+      // console.log( `Saving stripped tag: ${ stripped }`)
       return stripped;
    });
    // console.log(tags);

--- a/src/server/models/item.js
+++ b/src/server/models/item.js
@@ -94,18 +94,20 @@ function parseEntityTags(md) {
    // note down as a tag.
    let strongs = [];
    let ems = [];
-   marked.use( { 
-      walkTokens: token => {
-         // console.log( token );
-         if ( token.type === 'em' ) {
-            strongs.push( token.text );
-         }
-         if ( token.type === 'strong' ) {
-            strongs.push( token.text );
+   marked(
+      md, 
+      { 
+         walkTokens: token => {
+            // console.log( token );
+            if ( token.type === 'em' ) {
+               strongs.push( token.text );
+            }
+            if ( token.type === 'strong' ) {
+               strongs.push( token.text );
+            }
          }
       }
-    } );
-   marked(md);
+   );
 
    // Single array of all bold/italic items => tags.
    tags = strongs.concat(ems);


### PR DESCRIPTION
Fixes #120

This PR does a few things related to parsing markdown.

- Update marked lib to latest.
- Fixes a bug when importing content with GFM checkbox `- [ ]`. 
- Detects bold/italic as a tag at all levels.


#### Fix bug when importing content with GFM checkbox `- [ ]`
We render a copy of the content as plain text for our search index, and use [marked-plaintext](https://github.com/etler/marked-plaintext) to do this. It doesn't have a render func for checkbox (and may not be maintained). As a pragmatic workaround, we manually append a `checkbox` render func. 

The symptom was that the import would fail if it encountered a GFM checkbox, with js error `TypeError: this.renderer.checkbox is not a function`.

This has probably been an issue for some time (pre markdown 1.0, unrelated); I discovered because some of my content had checkboxes in it. 

#### Detect bold/italic at all levels
Bold and italic are used as tags too. However, bold and italic inside lists was missed.

Previously I was using the lexer to find text content and then running a markdown render on each content item with a custom renderer to detect bold/italic. The issue was that the lexer is a tree of nodes, not a simple array. For example, lists are a top-level item with sub-nodes for each list item.

The new technique uses [`walkTokens`](https://marked.js.org/using_pro#walk-tokens) instead, which is called for every token, anywhere in the tree.